### PR TITLE
Add --insecure flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.2.0]
+
+- Added `--insecure` to disable TLS verification for the TLS and webhook outputs.
+
 ## [0.1.0]
 
 ### Added
@@ -18,6 +22,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added pcap and log file inputs.
 - Added udp, tcp, and tls outputs.
 
-[Unreleased]: https://github.com/andrewkroh/stream/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/andrewkroh/stream/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/andrewkroh/stream/releases/tag/v0.2.0
 [0.1.0]: https://github.com/andrewkroh/stream/releases/tag/v0.1.0
 [0.0.1]: https://github.com/andrewkroh/stream/releases/tag/v0.0.1

--- a/command/root.go
+++ b/command/root.go
@@ -56,6 +56,7 @@ func ExecuteContext(ctx context.Context) error {
 	rootCmd.PersistentFlags().StringVarP(&opts.Protocol, "protocol", "p", "tcp", "protocol ("+strings.Join(output.Available(), "/")+")")
 	rootCmd.PersistentFlags().IntVar(&opts.Retries, "retry", 10, "connection retry attempts for tcp based protocols")
 	rootCmd.PersistentFlags().StringVarP(&opts.StartSignal, "start-signal", "s", "", "wait for start signal")
+	rootCmd.PersistentFlags().BoolVar(&opts.InsecureTLS, "insecure", false, "disable tls verification")
 
 	// Webhook output flags.
 	rootCmd.PersistentFlags().StringVar(&opts.WebhookOptions.ContentType, "webhook-content-type", "application/json", "webhook Content-Type")

--- a/pkg/output/options.go
+++ b/pkg/output/options.go
@@ -12,6 +12,7 @@ type Options struct {
 	Protocol    string        // Protocol (udp/tcp/tls).
 	Retries     int           // Number of connection retries for tcp based protocols.
 	StartSignal string        // OS signal to wait on before starting.
+	InsecureTLS bool          // Disable TLS verification checks.
 
 	WebhookOptions
 }

--- a/pkg/output/tls/tls.go
+++ b/pkg/output/tls/tls.go
@@ -29,7 +29,7 @@ func New(opts *output.Options) (output.Output, error) {
 func (o *Output) DialContext(ctx context.Context) error {
 	d := tls.Dialer{
 		Config: &tls.Config{
-			InsecureSkipVerify: true,
+			InsecureSkipVerify: o.opts.InsecureTLS,
 		},
 		NetDialer: &net.Dialer{Timeout: time.Second},
 	}

--- a/pkg/output/webhook/webhook.go
+++ b/pkg/output/webhook/webhook.go
@@ -7,6 +7,7 @@ package webhook
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -32,6 +33,11 @@ func New(opts *output.Options) (output.Output, error) {
 
 	client := &http.Client{
 		Timeout: time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: opts.InsecureTLS,
+			},
+		},
 	}
 
 	return &Output{opts: opts, client: client}, nil


### PR DESCRIPTION
Add --insecure flag to disable TLS verification for `tls` and `webhook` outputs.